### PR TITLE
Do not use macos-12 and Mambaforge in GitHub Actions

### DIFF
--- a/.github/workflows/conda-forge-ci.yml
+++ b/.github/workflows/conda-forge-ci.yml
@@ -15,7 +15,7 @@ jobs:
     strategy:
       matrix:
         build_type: [Release]
-        os: [ubuntu-latest, windows-2019, macos-14, macos-12]
+        os: [ubuntu-latest, windows-2019, macos-latest]
         imgui: [mamba, vendored]
       fail-fast: false
 
@@ -23,15 +23,9 @@ jobs:
     - uses: actions/checkout@v2
 
     - uses: conda-incubator/setup-miniconda@v3
-      if: matrix.os != 'macos-14'
       with:
         miniforge-variant: Mambaforge
         miniforge-version: latest
-
-    - uses: conda-incubator/setup-miniconda@v3
-      if: matrix.os == 'macos-14'
-      with:
-        installer-url: https://github.com/conda-forge/miniforge/releases/download/23.11.0-0/Mambaforge-23.11.0-0-MacOSX-arm64.sh
 
     - name: Dependencies
       shell: bash -l {0}

--- a/.github/workflows/conda-forge-ci.yml
+++ b/.github/workflows/conda-forge-ci.yml
@@ -24,7 +24,6 @@ jobs:
 
     - uses: conda-incubator/setup-miniconda@v3
       with:
-        miniforge-variant: Mambaforge
         miniforge-version: latest
 
     - name: Dependencies


### PR DESCRIPTION
Action required due to https://github.com/actions/runner-images/issues/10721, switch to `macos-latest` so we do not need to manually update the macos version manually every time.

Furthermore as required by https://github.com/conda-forge/miniforge/pull/615, we stop using `Mambaforge` and just use `Miniforge3` (as now mamba is also included there).